### PR TITLE
FQ42-14 Base Server

### DIFF
--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: maricard <maricard@student.porto.com>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/17 15:58:21 by maricard          #+#    #+#             */
-/*   Updated: 2024/01/18 17:06:51 by bsilva-c         ###   ########.fr       */
+/*   Updated: 2024/01/24 21:25:52 by bsilva-c         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,16 +36,15 @@ class Connection;
 class Request
 {
 	private:
-		std::string _method;
-		std::string _uri;
-		std::string _protocol;
+		std::string _method, _uri, _protocol;
 		std::string _path;
 		std::string _executable;
 		std::string _query;
 		std::map<std::string, std::string> _header;
 		std::vector<char> _body;
-		u_int32_t 	_bodyLength;
+		u_int32_t 	_contentLength;
 		std::string _uploadStore;
+		bool		_hasHeader;
 
 		Request& operator=(const Request& other);
 	
@@ -64,14 +63,16 @@ class Request
 		std::string getExtension();
 		std::string getExecutable() const;
 		std::string getHeaderField(const std::string& field);
+		u_int32_t getContentLength();
 
-		int		parseRequest(Cluster& cluster,
-							 Connection& connection,
-							 char* buffer,
-							 int64_t bytesAlreadyRead);
-		int		parseBody(int socket, char* chunk, int64_t bytesToRead);
-		int		parseChunkedRequest(int socket, char* buffer, int64_t bytesToRead);
+		void parseRequest(Cluster& cluster,
+						  Connection& connection,
+						  char* buffer,
+						  int64_t bytesAlreadyRead);
+		void parseBody(char* buffer, int64_t bytesRead);
+		void parseChunkedRequest();
 		int		checkErrors(Connection& connection);
 		void	displayVars();
 		int		isValidRequest(Server& server, int& error);
+		bool	hasHeader() const;
 };

--- a/includes/utils.hpp
+++ b/includes/utils.hpp
@@ -6,7 +6,7 @@
 /*   By: maricard <maricard@student.porto.com>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/10 20:16:23 by maricard          #+#    #+#             */
-/*   Updated: 2023/12/01 18:12:47 by maricard         ###   ########.fr       */
+/*   Updated: 2024/01/29 17:23:18 by maricard         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,3 +17,4 @@
 std::string	getFileExtension(std::string& path);
 uint32_t	getHexSize(const std::vector<char>& body, unsigned pos);
 uint32_t	getHexFromChunked(const std::vector<char>& body, unsigned pos);
+bool		searchChunkedRequestEnd(const std::vector<char>& body);

--- a/sources/Response.cpp
+++ b/sources/Response.cpp
@@ -6,7 +6,7 @@
 /*   By: maricard <maricard@student.porto.com>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 19:09:05 by bsilva-c          #+#    #+#             */
-/*   Updated: 2024/01/18 19:33:59 by bsilva-c         ###   ########.fr       */
+/*   Updated: 2024/01/29 15:41:43 by bsilva-c         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -226,6 +226,8 @@ std::string Response::buildErrorResponse(Connection& connection, int _errorCode)
 				ERROR)
 		response.append(std::string("HTTP/1.1 500 Internal Server Error") + CRLF);
 		response.append(std::string("Content-Type: text/html") + CRLF);
+		response.append(std::string("Content-Length: 30") + CRLF);
+		response.append(std::string("Connection: close") + CRLF);
 		response.append(std::string("Server: Webserv (Unix)") + CRLF);
 		response.append(CRLF);
 		response.append("<h1>Internal Server Error</h1>");
@@ -247,14 +249,13 @@ std::string Response::buildErrorResponse(Connection& connection, int _errorCode)
 			file.close();
 		}
 		else
-		LOG(connection.getConnectionID(),
-			file_name + ": " + (std::string)strerror(errno),
-			WARNING)
-		
-		goto createHttpResponse; 
+			LOG(connection.getConnectionID(),
+				file_name + ": " + (std::string)strerror(errno),
+				WARNING)
 	}
-	
-	htmlCode = "<!DOCTYPE html>\n"
+	else
+	{
+		htmlCode = "<!DOCTYPE html>\n"
 				"<html lang=\"en\">\n"
 				"\n"
 				"<head>\n"
@@ -300,13 +301,14 @@ std::string Response::buildErrorResponse(Connection& connection, int _errorCode)
 				"</body>\n"
 				"\n"
 				"</html>";
-	
-	createHttpResponse:
+	}
+
 		std::stringstream contentSize;
 		contentSize << htmlCode.size();
 		response.append("HTTP/1.1 " + errorCode.str() + " " + _errorStatus[errorCode.str()] + CRLF);
 		response.append(std::string("Content-Type: text/html") + CRLF);
 		response.append("Content-Length: " + contentSize.str() + CRLF);
+		response.append(std::string("Connection: close") + CRLF);
 		response.append(std::string("Server: Webserv (Unix)") + CRLF);
 		response.append(CRLF);
 		response.append(htmlCode);

--- a/sources/utils.cpp
+++ b/sources/utils.cpp
@@ -6,7 +6,7 @@
 /*   By: maricard <maricard@student.porto.com>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/10 20:09:21 by maricard          #+#    #+#             */
-/*   Updated: 2023/12/01 18:37:29 by maricard         ###   ########.fr       */
+/*   Updated: 2024/01/29 17:25:02 by maricard         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,4 +55,23 @@ uint32_t	getHexFromChunked(const std::vector<char>& body, unsigned pos)
 	ss >> std::hex >> value;
 
 	return value;
+}
+
+bool	searchChunkedRequestEnd(const std::vector<char>& body)
+{
+	std::string hex;
+	size_t pos = 0;
+
+	while (pos < body.size())
+	{
+		if (body[pos] == '0' &&
+			body[pos + 1] && body[pos + 1] == '\r' &&
+			body[pos + 2] && body[pos + 2] == '\n' &&
+			body[pos + 3] && body[pos + 3] == '\r' &&
+			body[pos + 4] && body[pos + 4] == '\n')
+			return true;
+		pos++;
+	}
+
+	return false;
 }


### PR DESCRIPTION
feat: Add support to handle multiple clients simultaneously, enhancing server performance and leveraging the select mechanism optimally
fix: Add "Content-Length" to HTTP header on error response
fix: Add "Connection: close" to HTTP header on error response, to prevent client from using socket after an error
refactor(Cluster.cpp): Cluster::sendResponse